### PR TITLE
docs: add `ADR-001` and `ADR-002` files.

### DIFF
--- a/docs/adr/0001 - Authentication
+++ b/docs/adr/0001 - Authentication
@@ -1,0 +1,48 @@
+## ADR-001 — Authentication Strategy
+
+**Date:** 2026-03-28
+**Status:** Accepted
+
+### Context
+
+The app needs a way to secure endpoints and associate documents with users. It will run initially as a local Docker instance (similar to Paperless-NGX), but may later evolve into a central service supporting multiple clients (web, desktop, mobile).
+
+Key constraints:
+- Auth should be simple enough to implement quickly for the initial version
+- It should not require a full rewrite when refresh tokens or OAuth2 (social login) are added later
+- The user expects to be logged out when they close the browser
+- The user does not want to be forced to re-authenticate frequently during a working session
+
+### Decision
+
+Use **JWT (JSON Web Token)** stored in **`sessionStorage`** on the frontend, with a **configurable expiry** controlled via an environment variable.
+
+- Token is issued on login and contains `user_id`, `email`, and `exp` (expiry)
+- Token is signed with a secret key using HS256
+- Expiry defaults to 12 hours, configurable via `TOKEN_EXPIRE_HOURS` in `.env`
+- Token is stored in `sessionStorage` — it is discarded when the browser is closed
+- Token is attached to every request via the frontend HTTP client in the `Authorization: Bearer <token>` header
+- Logout is a soft logout — the token is removed from `sessionStorage` on the frontend; no backend invalidation needed at this stage
+- The backend `get_current_user` dependency validates the JWT signature and expiry only — no database lookup required
+
+### Consequences
+
+- No token table in the database for the initial version — simplifies the backend
+- Closing the browser logs the user out automatically — matches expected UX
+- The API contract (Bearer token in Authorization header) remains stable across future versions
+- Refresh token logic can be added in a future version without changing the API interface — the frontend token management gets smarter, the backend stays the same
+- OAuth2 / social login can be added in a future version — external tokens get exchanged into internal JWTs, the rest of the system is unaffected
+
+### Alternatives considered
+
+| Option | Reason rejected |
+|--------|----------------|
+| Session-based (Django-style) | Requires DB lookup on every request; not idiomatic for a REST API |
+| JWT only with localStorage | Token survives browser close — not the desired UX |
+| JWT + refresh tokens now | Adds complexity not justified for a local single-user app at this stage |
+| OAuth2 now | Overkill for the initial version; planned for a future iteration |
+
+### Future direction
+
+- **Refresh tokens** — short-lived access token + long-lived refresh token in httpOnly cookie with silent renewal
+- **OAuth2 / social login** (Google, GitHub) — external tokens exchanged into internal JWTs; the rest of the system remains unaffected

--- a/docs/adr/0002 - File Storage
+++ b/docs/adr/0002 - File Storage
@@ -1,0 +1,65 @@
+## ADR-002 - File Storage Strategy
+
+**Date:** 2026-03-31
+**Status:** Accepted
+
+### Context
+
+The app stores user-uploaded files (document pages, attachments). It runs initially as a
+local Docker instance. Files need to be written, read, and deleted reliably, and the
+storage layer may be replaced with a remote object store (S3, GCS) in a future version.
+
+Key constraints:
+- Must work inside a Docker container from day one with no external dependencies
+- Business concepts (document, original filename) must stay independent of storage details
+- Swapping backends later must not require changes to upload/download handlers
+- Filenames on disk must not collide and must be filesystem-safe
+
+### Decision
+
+Use the **local filesystem mounted via a Docker volume**, behind a **`StorageBackend` Protocol**,
+for the initial version.
+
+Files are stored using a UUID-based path:
+
+```
+/storage/uploads/{user_id}/{document_id}/{file_id}.{ext}
+```
+
+- `STORAGE_PATH` env var controls the mount point; defaults to `/storage`
+- `user_id` prefix partitions data per user and maps to future S3 key prefix policies
+- Files are named `{uuid}.{ext}` - UUID for uniqueness, extension retained for debuggability
+- The relative path is the **storage key**, persisted in `DocumentFile.storage_key`
+- The original filename supplied by the uploader is stored in `DocumentFile.original_filename`
+  in the database - it is never derived from the filesystem
+- `Document.title` defaults to `Path(original_filename).stem` of the first uploaded file
+  and is user-editable
+- A `StorageBackend` Protocol defines `save`, `load`, `delete`, and `exists`
+- `LocalFileStorage` implements the Protocol; `save` writes atomically via temp file + rename
+- A FastAPI `get_storage()` dependency returns the active backend - all handlers are
+  backend-agnostic
+
+### Consequences
+
+- No external infrastructure needed for initial version - a single Docker volume is sufficient
+- Swapping to S3 or GCS requires only a new `StorageBackend` implementation and an env-var
+  toggle; no handler changes
+- Horizontal scaling before a remote store is introduced requires a shared volume (NFS, EFS)
+  - acceptable for a local single-instance app at this stage
+- Callers must not assume durability until `save()` returns (atomic write contract)
+
+### Alternatives considered
+
+| Option | Reason rejected |
+|--------|----------------|
+| Store under original filename | Collisions, encoding issues, leaks user data in paths |
+| Single flat directory | No partitioning; impractical at scale |
+| S3 from day one | Unnecessary infra complexity before the product is proven |
+| SQLite BLOB storage | Not viable for large files; prevents streaming |
+
+### Future direction
+
+- **Remote object store (S3 / GCS)** - implement `S3StorageBackend`, toggle via env var;
+  no upload/download handler changes required
+- **Per-user storage quotas** - enforced at the `save()` boundary in the Protocol
+- **Virus scanning / MIME validation** - can be added as a decorator over `StorageBackend`


### PR DESCRIPTION
## What
Re-adds ADR-001 (Authentication Strategy) and adds ADR-002 (File Storage Strategy).

## Why
Add again the ADR-001 file with the auth strategy and add ADR-002 with file storage strategy agreed for initial version.

## Changes
- **Re-added `docs/adr/0001 - Authentication`:** No content changes from the original.
- **Added `docs/adr/0002 - File Storage`:** New ADR covering storage path layout,
  UUID-based filenames, `StorageBackend` Protocol abstraction, and future S3 migration path

## Notes
ADR-002 notes that the `{user_id}` prefix in the storage path may conflict with
S3 IAM prefix policies if shared documents are introduced later. This is flagged
in the future direction section; no action needed yet.